### PR TITLE
Various improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ target_sources(uv-co-promise INTERFACE
     uvco/promise/multipromise.h
     uvco/promise/promise.h
     uvco/promise/promise_core.h
+    uvco/promise/promise_refcount.h
     uvco/promise/select.h
 )
 target_link_libraries(uv-co-promise PRIVATE uv-co-base)
@@ -158,6 +159,7 @@ target_sources(uv-co-lib INTERFACE
     FILES
     uvco/async_work.h
     uvco/bounded_queue.h
+    uvco/cancellation_block.h
     uvco/channel.h
     uvco/close.h
     uvco/combinators.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ target_sources(uv-co-promise INTERFACE
     uvco/promise/multipromise.h
     uvco/promise/promise.h
     uvco/promise/promise_core.h
+    uvco/promise/select.h
 )
 target_link_libraries(uv-co-promise PRIVATE uv-co-base)
 target_include_directories(uv-co-promise PRIVATE .)
@@ -156,6 +157,7 @@ target_sources(uv-co-lib INTERFACE
     TYPE HEADERS
     FILES
     uvco/async_work.h
+    uvco/bounded_queue.h
     uvco/channel.h
     uvco/close.h
     uvco/combinators.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,8 @@ if(CURL_FOUND)
     target_include_directories(uv-co-curl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
     install(TARGETS uv-co-curl)
     install(TARGETS uv-co-curl FILE_SET HEADERS DESTINATION include/uvco)
+    set(GENPKGCONFIG_EXTRA_REQUIRES "${GENPKGCONFIG_EXTRA_REQUIRES}, libcurl")
+    set(GENPKGCONFIG_EXTRA_LIBS "${GENPKGCONFIG_EXTRA_LIBS} -luv-co-curl")
 endif()
 
 if(libpqxx_FOUND)
@@ -230,6 +232,8 @@ if(libpqxx_FOUND)
     target_include_directories(uv-co-pqxx PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
     install(TARGETS uv-co-pqxx)
     install(TARGETS uv-co-pqxx FILE_SET HEADERS DESTINATION include/uvco)
+    set(GENPKGCONFIG_EXTRA_REQUIRES "${GENPKGCONFIG_EXTRA_REQUIRES}, libpqxx")
+    set(GENPKGCONFIG_EXTRA_LIBS "${GENPKGCONFIG_EXTRA_LIBS} -luv-co-pqxx")
 endif()
 
 # Unit tests
@@ -339,6 +343,16 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 else()
     set(GCOV_BINARY "gcov")
 endif()
+
+# Pkg-config
+
+configure_file(uvco.pc.in
+  uvco.pc @ONLY)
+
+install(
+ FILES ${CMAKE_CURRENT_BINARY_DIR}/uvco.pc
+ DESTINATION lib/pkgconfig
+)
 
 add_custom_target(coverage
     COMMAND mkdir -p coverage

--- a/test/http_server_test.cc
+++ b/test/http_server_test.cc
@@ -106,8 +106,8 @@ TEST(HttpServerTest, invalidRequest) {
         EXPECT_TRUE(response.find("400 Bad Request") != std::string::npos);
 
         // Check what happens if we write to the (remotely) closed stream
-        EXPECT_LT(16, co_await stream.write(
-                          "GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+        co_await stream.write(
+            "GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
         EXPECT_EQ(0, co_await stream.read(buffer));
 
         stream.close();

--- a/test/loop_test.cc
+++ b/test/loop_test.cc
@@ -31,7 +31,7 @@ TEST(LoopTest, createNestedLoopFails) {
 }
 
 TEST(LoopTest, noLoop) {
-  EXPECT_THROW({ Loop::enqueue(std::coroutine_handle<>{}); }, UvcoException);
+  EXPECT_THROW({ Loop::enqueue({}); }, UvcoException);
 }
 
 TEST(LoopTest, exceptionLeavesLoop) {

--- a/test/promise_test.cc
+++ b/test/promise_test.cc
@@ -215,7 +215,8 @@ TYPED_TEST(RvalueCoroutineFixture, rvalueCoroutine) {
 
 struct YieldAwaiter_ {
   [[nodiscard]] static bool await_ready() noexcept { return false; }
-  bool await_suspend(std::coroutine_handle<> handle) noexcept {
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle) noexcept {
     Loop::enqueue(handle);
     return true;
   }

--- a/test/stream_test.cc
+++ b/test/stream_test.cc
@@ -114,8 +114,8 @@ TEST(PipeTest, largeWriteRead) {
     auto [read, write] = pipe(loop);
 
     for (unsigned i = 0; i < 10; ++i) {
-      EXPECT_EQ(buffer.size(), co_await write.write(
-                                   std::string(buffer.data(), buffer.size())));
+      co_await write.write(
+          std::string(buffer.data(), buffer.size()));
     }
     write.close();
 

--- a/test/tcp-broadcaster.exe.cc
+++ b/test/tcp-broadcaster.exe.cc
@@ -66,7 +66,7 @@ public:
 
   Promise<void> broadcast(std::string_view from, std::string_view what) {
     const std::string message = fmt::format("{} says: {}", from, what);
-    std::vector<Promise<size_t>> promises;
+    std::vector<Promise<void>> promises;
     promises.reserve(clients_.size());
 
     for (const auto &clientPtr : clients_) {

--- a/uvco.pc.in
+++ b/uvco.pc.in
@@ -1,0 +1,11 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${exec_prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: fmt >= 9.0, libuv >= 1.0@GENPKGCONFIG_EXTRA_REQUIRES@
+Cflags: -I${includedir}
+Libs: -L${libdir}@GENPKGCONFIG_EXTRA_LIBS@ -luv-co-lib -luv-co-base -luv-co-promise

--- a/uvco/async_work.cc
+++ b/uvco/async_work.cc
@@ -63,7 +63,8 @@ public:
     return status_.has_value();
   }
 
-  bool await_suspend(std::coroutine_handle<> handle) {
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle) {
     BOOST_ASSERT(!status_);
     BOOST_ASSERT(!handle_);
     BOOST_ASSERT_MSG(!handle_, "AsyncWorkAwaiter_ can only be awaited once");
@@ -83,7 +84,7 @@ private:
   std::unique_ptr<uv_work_t> work_;
   std::function<void()> function_;
   std::optional<uv_status> status_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
 
   void invoke() {
     BOOST_ASSERT(function_ != nullptr);
@@ -92,8 +93,8 @@ private:
 
   void schedule() {
     if (handle_) {
-      const std::coroutine_handle<> handle = handle_;
-      handle_ = nullptr;
+      const auto handle = handle_;
+      handle_ = {};
       Loop::enqueue(handle);
     }
   }

--- a/uvco/cancellation_block.h
+++ b/uvco/cancellation_block.h
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 kimapr.  See LICENSE for specific terms.
+
+#include "uvco/promise/promise_refcount.h"
+#include "uvco/loop/loop.h"
+#include "uvco/combinators.h"
+
+#pragma once
+
+namespace uvco {
+
+/// This object prevents the coroutine in which it was created, as well as
+/// the entire async "call stack" from being destroyed early.
+///
+/// This is useful when performing an operation that cannot be safely
+/// cancelled, to ensure that all the objects it references continue to exist.
+///
+/// Constructing the object begins the block, destruction ends it. The object
+/// can also be `co_awaited` to end the block without waiting for the next loop
+/// cycle.
+class CancellationBlock {
+  CoroutineHandle target;
+
+  struct InitialSuspendAwaiter {
+    std::coroutine_handle<> *coro;
+
+    bool await_ready() { return false; }
+    bool await_suspend(std::coroutine_handle<> scoro) {
+      *coro = scoro;
+      return true;
+    }
+    void await_resume() {}
+  };
+public:
+  CancellationBlock() {
+    target = RunningCoroutine::get();
+    PromiseRefcounter_::acquireRecursive(target.ref);
+  }
+  CancellationBlock(const CancellationBlock &) = delete;
+  CancellationBlock(CancellationBlock &&) = delete;
+  CancellationBlock &operator=(const CancellationBlock &) = delete;
+  CancellationBlock &operator=(CancellationBlock &&) = delete;
+
+  bool await_ready() { return false; }
+  bool await_suspend(std::coroutine_handle<>) {
+    auto tg = target;
+    target = {};
+    PromiseRefcounter_::releaseRecursive(tg.ref);
+    if (tg.ref->uses()) return false;
+    return true;
+  }
+  void await_resume() {}
+
+  ~CancellationBlock() {
+    if (!target) return;
+    detach(([](auto target) -> Promise<void>{
+      co_await yield();
+      auto tg = target;
+      PromiseRefcounter_::releaseRecursive(tg.ref);
+    })(std::move(target)));
+  }
+};
+
+} // namespace uvco

--- a/uvco/channel.h
+++ b/uvco/channel.h
@@ -116,12 +116,12 @@ private:
   BoundedQueue<T> queue_;
   // TODO: a multi-reader/writer queue is easily achieved by converting the
   // optionals into queues. This may be interesting in future.
-  BoundedQueue<std::coroutine_handle<>> read_waiting_;
-  BoundedQueue<std::coroutine_handle<>> write_waiting_;
+  BoundedQueue<CoroutineHandle> read_waiting_;
+  BoundedQueue<CoroutineHandle> write_waiting_;
 
   void awake_reader() {
     while (!read_waiting_.empty()) {
-      std::coroutine_handle<void> handle = read_waiting_.get();
+      auto handle = read_waiting_.get();
       // Skip cancelled coroutines.
       if (handle != nullptr) {
         Loop::enqueue(handle);
@@ -132,7 +132,7 @@ private:
 
   void awake_writer() {
     while (!write_waiting_.empty()) {
-      std::coroutine_handle<void> handle = write_waiting_.get();
+      auto handle = write_waiting_.get();
       if (handle != nullptr) {
         Loop::enqueue(handle);
         break;
@@ -142,11 +142,11 @@ private:
 
   struct ChannelAwaiter_ {
     explicit ChannelAwaiter_(BoundedQueue<T> &queue,
-                             BoundedQueue<std::coroutine_handle<>> &slot)
+                             BoundedQueue<CoroutineHandle> &slot)
         : queue_{queue}, waiters_{slot} {}
     ~ChannelAwaiter_() {
       // Remove us from waiters.
-      waiters_.forEach([this](std::coroutine_handle<> &h) {
+      waiters_.forEach([this](CoroutineHandle &h) {
         // Remove pending coroutine from waiter queue.
         if (h == thisCoro_) {
           h = nullptr;
@@ -156,7 +156,8 @@ private:
 
     bool await_ready() { return false; }
 
-    bool await_suspend(std::coroutine_handle<> handle) {
+    template<class PT>
+    bool await_suspend(std::coroutine_handle<PT> handle) {
       if (!waiters_.hasSpace()) {
         throw UvcoException(
             UV_EBUSY,
@@ -171,7 +172,7 @@ private:
 
     // References Channel<T>::queue_
     BoundedQueue<T> &queue_;
-    BoundedQueue<std::coroutine_handle<>> &waiters_;
+    BoundedQueue<CoroutineHandle> &waiters_;
     std::coroutine_handle<> thisCoro_;
   };
 };

--- a/uvco/combinators.cc
+++ b/uvco/combinators.cc
@@ -87,13 +87,32 @@ public:
   ~TaskSetImpl() override = default;
 
 private:
+  struct InitialSuspendAwaiter {
+    std::coroutine_handle<> *coro;
+
+    bool await_ready() { return false; }
+    bool await_suspend(std::coroutine_handle<> scoro) {
+      *coro = scoro;
+      return true;
+    }
+    void await_resume() {}
+  };
+
   Id add(Promise<void> task) override {
-    const Id taskId = counter_++;
-    tasks_.insert({taskId, wrap(taskId, std::move(task))});
+    Id taskId;
+    // Make sure the task id isn't taken, just in case.
+    do {
+      taskId = counter_++;
+    } while(tasks_.find(taskId) != tasks_.end());
+
+    std::coroutine_handle<> coro;
+    tasks_.insert({taskId, wrap(taskId, std::move(task), InitialSuspendAwaiter(&coro))});
+    // Resume the task, since it's starts up suspended.
+    coro();
     return taskId;
   }
 
-  bool empty() override { return 0 == tasks_.size() - doneTasks_.size(); }
+  bool empty() override { return 0 == tasks_.size(); }
 
   Promise<void> onEmpty() override {
     if (empty()) {
@@ -106,15 +125,13 @@ private:
     errorCallback_ = std::move(ecb);
   }
 
-  Promise<void> wrap(Id taskId, Promise<void> task_) {
-    // Move task to a temporary variable so that it cleaned up immediately,
-    // rather than after another task is added to TaskSet.
-    // Normally, coroutine arguments are cleaned up only after Promise is
-    // destroyed.
-    Promise<void> task = std::move(task_);
+  Promise<void> wrap(Id taskId, Promise<void> task, InitialSuspendAwaiter initial_suspend) {
+    // Suspend initially to ensure that task is inserted in add() before this
+    // function touches tasks_
+    co_await initial_suspend;
 
-    // Wait for task to finish; do regular housekeeping; then mark current task
-    // as ready for cleanup.
+    // Wait for task to finish; do regular housekeeping; then clean up the
+    // current task.
     try {
       co_await task;
     } catch (const std::exception &e) {
@@ -140,27 +157,29 @@ private:
     // Already trigger onEmpty if no more tasks are left. Otherwise this leads
     // to a deadlock-like problem, as no more tasks will run to trigger the
     // cleanup, and thus notify onEmpty.
-    if (tasks_.size() - doneTasks_.size() - 1 == 0) {
+    if (tasks_.size() - 1 == 0) {
       onEmpty_.releaseAll();
     }
 
-    // Drop finished tasks.
-    while (!doneTasks_.empty()) {
-      tasks_.erase(doneTasks_.front());
-      doneTasks_.pop_front();
-    }
+    // Using an awaiter allows the coroutine to delete itself cleanly and safely.
+    struct DestroyAwaiter {
+      decltype(tasks_) *p_tasks;
+      Id taskId;
+      DestroyAwaiter(decltype(p_tasks) tasks_, Id taskId) : p_tasks(tasks_), taskId(taskId) {}
+      bool await_ready() { return false; }
+      bool await_suspend(std::coroutine_handle<>) {
+        p_tasks->erase(taskId);
+        return true;
+      }
+      void await_resume() {}
+    } destroyAwaiter(&tasks_, taskId);
 
-    // We cannot erase the task directly here, as the task in tasks_ refers to
-    // this very coroutine. Therefore, mark it for cleanup and deal with it
-    // later.
-    doneTasks_.push_back(taskId);
+    co_await destroyAwaiter;
   }
 
   Id counter_ = 0;
   std::unordered_map<Id, Promise<void>> tasks_{};
   ErrorCallback errorCallback_;
-  // List of finished tasks for delayed clean-up.
-  std::deque<Id> doneTasks_{};
   WaitPoint onEmpty_{};
 };
 

--- a/uvco/combinators.cc
+++ b/uvco/combinators.cc
@@ -21,7 +21,8 @@ namespace {
 
 struct YieldAwaiter_ {
   [[nodiscard]] static bool await_ready() noexcept { return false; }
-  bool await_suspend(std::coroutine_handle<> handle) noexcept {
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle) noexcept {
     Loop::enqueue(handle);
     // Ensure that loop runs existing promises.
     return true;
@@ -44,8 +45,9 @@ struct WaitPoint::WaitPointAwaiter_ {
 
   [[nodiscard]] static bool await_ready() { return false; }
 
+  template<class T>
   [[nodiscard]] std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> handle) const {
+  await_suspend(std::coroutine_handle<T> handle) const {
     waitPoint_.enqueue(handle);
     return Loop::getNext();
   }
@@ -71,7 +73,7 @@ void WaitPoint::releaseAll() {
   }
 }
 
-void WaitPoint::enqueue(std::coroutine_handle<> handle) {
+void WaitPoint::enqueue(CoroutineHandle handle) {
   waiters_.push_back(handle);
 }
 

--- a/uvco/combinators.cc
+++ b/uvco/combinators.cc
@@ -106,7 +106,13 @@ private:
     errorCallback_ = std::move(ecb);
   }
 
-  Promise<void> wrap(Id taskId, Promise<void> task) {
+  Promise<void> wrap(Id taskId, Promise<void> task_) {
+    // Move task to a temporary variable so that it cleaned up immediately,
+    // rather than after another task is added to TaskSet.
+    // Normally, coroutine arguments are cleaned up only after Promise is
+    // destroyed.
+    Promise<void> task = std::move(task_);
+
     // Wait for task to finish; do regular housekeeping; then mark current task
     // as ready for cleanup.
     try {

--- a/uvco/combinators.h
+++ b/uvco/combinators.h
@@ -73,6 +73,44 @@ Promise<void> raceIgnore(Promise<PromiseTypes>... promises) {
   co_await selectSet;
 }
 
+/// Run a task in the background, without having to keep any promise handle
+/// around. If the promise throws an exception, the entire program will be
+/// terminated.
+template<typename T>
+void detach(Promise<T> task) {
+  Promise<void> *detachable = std::allocator<Promise<void>>().allocate(1);
+  std::coroutine_handle<> coro;
+  struct InitialSuspendAwaiter {
+    std::coroutine_handle<> *coro;
+    bool await_ready() { return false; }
+    bool await_suspend(std::coroutine_handle<> scoro) {
+      *coro = scoro;
+      return true;
+    }
+    void await_resume() {}
+    Promise<void> fire(Promise<void> *detachable, Promise<T> task) {
+      co_await *this;
+      try {
+        co_await task;
+      } catch(...) {
+        std::terminate();
+      }
+      struct DestroyAwaiter {
+        Promise<void> *detachable;
+        bool await_ready() { return false; }
+        bool await_suspend(std::coroutine_handle<>) {
+          delete detachable;
+          return true;
+        }
+        void await_resume() {}
+      } destroyer(detachable);
+      co_await destroyer;
+    }
+  } suspender(&coro);
+  std::construct_at(detachable, suspender.fire(detachable, std::move(task)));
+  coro.resume();
+}
+
 namespace detail {
 
 template <typename T> struct ReplaceVoid {
@@ -126,8 +164,8 @@ public:
   void releaseAll();
 
 private:
-  void enqueue(std::coroutine_handle<> handle);
-  std::deque<std::coroutine_handle<>> waiters_;
+  void enqueue(CoroutineHandle handle);
+  std::deque<CoroutineHandle> waiters_;
 };
 
 /// TaskSet handles the common case of maintaining a set of coroutines running

--- a/uvco/fs.cc
+++ b/uvco/fs.cc
@@ -73,7 +73,8 @@ public:
     return result_.has_value();
   }
 
-  bool await_suspend(std::coroutine_handle<> handle) {
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle) {
     BOOST_ASSERT(!result_);
     BOOST_ASSERT_MSG(!handle_, "FileOpAwaiter_ can only be awaited once");
     BOOST_ASSERT(requestDataIsNull(req_.get()));
@@ -99,13 +100,13 @@ public:
 
 private:
   std::unique_ptr<uv_fs_t> req_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   std::optional<ssize_t> result_ = std::nullopt;
 
   void schedule() {
     if (handle_) {
       Loop::enqueue(handle_);
-      handle_ = nullptr;
+      handle_ = {};
     }
   }
 };
@@ -323,7 +324,8 @@ struct FsWatch::FsWatchAwaiter_ {
   FsWatchAwaiter_();
 
   [[nodiscard]] bool await_ready() const;
-  void await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  void await_suspend(std::coroutine_handle<T> handle);
   bool await_resume();
 
   void schedule();
@@ -331,7 +333,7 @@ struct FsWatch::FsWatchAwaiter_ {
   void addError(uv_status status);
   void addEvent(FileEvent event);
 
-  std::optional<std::coroutine_handle<>> handle_;
+  std::optional<CoroutineHandle> handle_;
   BoundedQueue<FileEvent> events_;
   bool stopped_{};
 };
@@ -342,7 +344,8 @@ bool FsWatch::FsWatchAwaiter_::await_ready() const {
   return stopped_ || !events_.empty();
 }
 
-void FsWatch::FsWatchAwaiter_::await_suspend(std::coroutine_handle<> handle) {
+template<class T>
+void FsWatch::FsWatchAwaiter_::await_suspend(std::coroutine_handle<T> handle) {
   BOOST_ASSERT(!handle_);
   handle_ = handle;
 }
@@ -355,8 +358,8 @@ bool FsWatch::FsWatchAwaiter_::await_resume() {
 
 void FsWatch::FsWatchAwaiter_::schedule() {
   if (handle_) {
-    std::coroutine_handle<> handle = handle_.value();
-    handle_.reset();
+    auto handle = std::move(handle_.value());
+    handle_ = {};
     Loop::enqueue(handle);
   }
 }

--- a/uvco/integrations/curl/curl.cc
+++ b/uvco/integrations/curl/curl.cc
@@ -295,7 +295,8 @@ public:
   }
 
   /// Awaiter protocol: suspend the downloader coroutine.
-  bool await_suspend(std::coroutine_handle<> handle) noexcept {
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle) noexcept {
     BOOST_ASSERT(!downloaderHandle_);
     downloaderHandle_ = handle;
     return true;
@@ -382,7 +383,7 @@ private:
 
   std::string url_;
   std::optional<std::string> payload_;
-  std::optional<std::coroutine_handle<>> downloaderHandle_;
+  std::optional<CoroutineHandle> downloaderHandle_;
 
   // Misuse vector as deque for now.
   std::vector<std::string> chunks_;

--- a/uvco/loop/loop.cc
+++ b/uvco/loop/loop.cc
@@ -91,7 +91,7 @@ Scheduler &Loop::currentScheduler() {
   return defaultLoop->scheduler_;
 }
 
-void Loop::enqueue(std::coroutine_handle<> handle) {
+void Loop::enqueue(CoroutineHandle handle) {
   currentScheduler().enqueue(handle);
   // If any handles are present, ensure that uv_run returns from waiting for I/O
   // soon.
@@ -99,10 +99,20 @@ void Loop::enqueue(std::coroutine_handle<> handle) {
     uv_stop(defaultLoop->uvloop());
     defaultLoop->stopped_ = true;
   }
+
+  if constexpr (logSchedulerOperations) {
+    fmt::print("Enqueuing coroutine {:x}\n",
+               (uintptr_t)((std::coroutine_handle<>)handle).address());
+  }
 }
 
 void Loop::cancel(std::coroutine_handle<> handle) {
   currentScheduler().cancel(handle);
+
+  if constexpr (logSchedulerOperations) {
+    fmt::print("Cancelling coroutine {:x}\n",
+               (uintptr_t)((std::coroutine_handle<>)handle).address());
+  }
 }
 
 std::coroutine_handle<> Loop::getNext() { return currentScheduler().getNext(); }

--- a/uvco/loop/loop.h
+++ b/uvco/loop/loop.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
+#include <type_traits>
 #include <uv.h>
+#include <coroutine>
 
 #include "uvco/exception.h"
 #include "uvco/loop/scheduler.h"
-
-#include <coroutine>
 
 namespace uvco {
 
@@ -37,7 +37,14 @@ public:
   [[nodiscard]] uv_loop_t *uvloop() const;
 
   // Enqueue a suspended coroutine_handle for later resumption.
-  static void enqueue(std::coroutine_handle<> handle);
+  static void enqueue(CoroutineHandle handle);
+
+  template<class T>
+    requires(std::is_same_v<T, void>)
+  static void enqueue(std::coroutine_handle<T>) {
+    static_assert(false, "Loop::enqueue() cannot accept a type-erased handle, define your await_suspend() as a templated function.");
+  }
+
   // Remove a handle from the event loop. Note: if the same handle is posted
   // again later, it may still be resumed.
   static void cancel(std::coroutine_handle<> handle);

--- a/uvco/loop/scheduler.cc
+++ b/uvco/loop/scheduler.cc
@@ -3,10 +3,9 @@
 #include <cstdint>
 #include <fmt/core.h>
 #include <uv.h>
+#include <coroutine>
 
 #include "uvco/loop/scheduler.h"
-
-#include <coroutine>
 
 namespace uvco {
 
@@ -20,10 +19,10 @@ static constexpr bool useSymmetricHandoff = true;
 
 void Scheduler::runAll() {
   while (!resumable_.empty()) {
-    const std::coroutine_handle<> next = getNextInner();
-    BOOST_ASSERT(next != nullptr && !next.done());
+    const auto next = getNextInner();
+    BOOST_ASSERT(next != nullptr && !((std::coroutine_handle<>)next).done());
     if constexpr (logSchedulerOperations) {
-      fmt::print("Resuming coroutine {:x}\n", (uintptr_t)next.address());
+      fmt::print("Resuming coroutine {:x}\n", (uintptr_t)((std::coroutine_handle<>)next).address());
     }
     next.resume();
   }
@@ -31,9 +30,9 @@ void Scheduler::runAll() {
 
 void Scheduler::close() { BOOST_ASSERT(resumable_.empty()); }
 
-void Scheduler::enqueue(std::coroutine_handle<> handle) {
+void Scheduler::enqueue(CoroutineHandle handle) {
   if constexpr (logSchedulerOperations) {
-    fmt::print("Enqueuing coroutine {:x}\n", (uintptr_t)handle.address());
+    fmt::print("Enqueuing coroutine {:x}\n", (uintptr_t)((std::coroutine_handle<>)handle).address());
   }
   resumable_.push_back(handle);
 }
@@ -49,30 +48,32 @@ void Scheduler::cancel(std::coroutine_handle<> handle) {
 
   for (auto &it : resumable_) {
     if (it == handle) {
-      it = nullptr;
+      it = {};
     }
   }
 }
 
 std::coroutine_handle<> Scheduler::getNext() {
   if constexpr (useSymmetricHandoff) {
-    return getNextInner();
+    auto v = getNextInner();
+    RunningCoroutine::set(v);
+    return v;
   } else {
     return std::noop_coroutine();
   }
 }
 
-std::coroutine_handle<> Scheduler::getNextInner() {
-  std::coroutine_handle<> next{nullptr};
-  while (!resumable_.empty() && (next == nullptr || next.done())) {
+CoroutineHandle Scheduler::getNextInner() {
+  CoroutineHandle next;
+  while (!resumable_.empty() && ((next == nullptr || ((std::coroutine_handle<>)next).done()))) {
     next = resumable_.front();
     resumable_.pop_front();
   }
-  if (next == nullptr || next.done()) {
-    return std::noop_coroutine();
+  if (next == nullptr || ((std::coroutine_handle<>)next).done()) {
+    return {};
   }
   if constexpr (logSchedulerOperations) {
-    fmt::print("Dequeuing coroutine {:x}, {} left\n", (uintptr_t)next.address(),
+    fmt::print("Dequeuing coroutine {:x}, {} left\n", (uintptr_t)((std::coroutine_handle<>)next).address(),
                resumable_.size());
   }
   return next;

--- a/uvco/loop/scheduler.cc
+++ b/uvco/loop/scheduler.cc
@@ -20,7 +20,6 @@ static constexpr bool useSymmetricHandoff = true;
 void Scheduler::runAll() {
   while (!resumable_.empty()) {
     const auto next = getNextInner();
-    BOOST_ASSERT(next != nullptr && !((std::coroutine_handle<>)next).done());
     if constexpr (logSchedulerOperations) {
       fmt::print("Resuming coroutine {:x}\n", (uintptr_t)((std::coroutine_handle<>)next).address());
     }

--- a/uvco/loop/scheduler.h
+++ b/uvco/loop/scheduler.h
@@ -8,6 +8,8 @@
 #include <coroutine>
 #include <deque>
 
+#include "uvco/promise/promise_refcount.h"
+
 namespace uvco {
 
 /// @addtogroup Scheduler
@@ -52,7 +54,7 @@ public:
   ~Scheduler();
 
   /// Schedule a coroutine for resumption.
-  void enqueue(std::coroutine_handle<> handle);
+  void enqueue(CoroutineHandle handle);
 
   void cancel(std::coroutine_handle<> handle);
 
@@ -79,9 +81,9 @@ public:
   [[nodiscard]] bool empty() const { return resumable_.empty(); }
 
 private:
-  std::coroutine_handle<> getNextInner();
+  CoroutineHandle getNextInner();
 
-  std::deque<std::coroutine_handle<>> resumable_;
+  std::deque<CoroutineHandle> resumable_;
 };
 
 } // namespace uvco

--- a/uvco/name_resolution.cc
+++ b/uvco/name_resolution.cc
@@ -176,7 +176,8 @@ struct AddrinfoAwaiter_ {
   ~AddrinfoAwaiter_();
 
   bool await_ready();
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
 
   struct addrinfo *await_resume();
 
@@ -184,7 +185,7 @@ struct AddrinfoAwaiter_ {
   std::unique_ptr<uv_getaddrinfo_t> req_;
   std::optional<struct addrinfo *> addrinfo_;
   std::optional<int> status_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
 };
 
 AddrinfoAwaiter_::AddrinfoAwaiter_()
@@ -210,7 +211,8 @@ struct addrinfo *AddrinfoAwaiter_::await_resume() {
   return *addrinfo_;
 }
 
-bool AddrinfoAwaiter_::await_suspend(std::coroutine_handle<> handle) {
+template<class T>
+bool AddrinfoAwaiter_::await_suspend(std::coroutine_handle<T> handle) {
   handle_ = handle;
   setRequestData(req_.get(), this);
   return true;
@@ -260,7 +262,7 @@ void Resolver::onAddrinfo(uv_getaddrinfo_t *req, uv_status status,
   }
   awaiter->addrinfo_ = result;
   awaiter->status_ = status;
-  BOOST_ASSERT(awaiter->handle_ != nullptr);
+  BOOST_ASSERT(awaiter->handle_);
   Loop::enqueue(awaiter->handle_);
 }
 

--- a/uvco/promise/multipromise.h
+++ b/uvco/promise/multipromise.h
@@ -6,6 +6,7 @@
 #include "uvco/loop/loop.h"
 #include "uvco/promise/promise.h"
 #include "uvco/promise/promise_core.h"
+#include "uvco/promise/promise_refcount.h"
 
 #include <coroutine>
 #include <exception>
@@ -39,7 +40,7 @@ public:
   /// In contrast to a `PromiseCore`, a finished
   /// multipromise core can be reset to the waiting state, in order to yield the
   /// next value, when the MultiPromise is `co_await`ed again.
-  void setHandle(std::coroutine_handle<> handle) override {
+  void setHandle(CoroutineHandle handle) override {
     // Once an external scheduler works, Promises will not be nested anymore
     // (resume called by resume down in the stack)
     //
@@ -65,9 +66,10 @@ public:
   void resumeGenerator() {
     BOOST_ASSERT(PromiseCore<T>::state_ != PromiseState::finished);
     if (suspended_) {
-      BOOST_ASSERT(coroutine_ != nullptr);
+      BOOST_ASSERT(coroutine_);
+      CoroutineHandle coro(coroutine_, PromiseCore<T>::refcount_.inner);
       suspended_ = false;
-      Loop::enqueue(coroutine_);
+      Loop::enqueue(coro);
     }
   }
 
@@ -88,12 +90,8 @@ public:
   /// Called by tje `MultiPromise` destructor and `MultiPromise::cancel()`.
   void cancelGenerator() {
     setTerminated();
-    if (coroutine_ != nullptr) {
-      const std::coroutine_handle<> coroutine = coroutine_;
-      coroutine_ = nullptr;
-      Loop::cancel(coroutine);
-      // Careful: within this function, this class' dtor is called!
-      coroutine.destroy();
+    if (coroutine_ != nullptr && !cancelled_) {
+      PromiseCore<T>::refcount_.release();
     }
   }
 
@@ -111,6 +109,7 @@ private:
   bool suspended_ = false;
   /// Set to true once the generator coroutine has returned or has been
   /// cancelled.
+  bool cancelled_ = false;
   bool terminated_ = false;
 };
 
@@ -223,8 +222,9 @@ protected:
     }
     /// Part of the coroutine protocol. Always returns `true`; stores the
     /// suspension handle in the MultiPromiseCore for later resumption.
+    template<class PT>
     [[nodiscard]] std::coroutine_handle<>
-    await_suspend(std::coroutine_handle<> handle) const {
+    await_suspend(std::coroutine_handle<PT> handle) const {
       if (core_ == nullptr) {
         return Loop::getNext();
       }
@@ -302,7 +302,9 @@ public:
   // Note: if suspend_always is chosen, we can better control when the
   // MultiPromise will be scheduled.
   std::suspend_never initial_suspend() noexcept {
-    core_.setRunning(std::coroutine_handle<Generator<T>>::from_promise(*this));
+    auto handle = std::coroutine_handle<Generator<T>>::from_promise(*this);
+    core_.setRunning(handle);
+    RunningCoroutine::set(handle);
     return {};
   }
 
@@ -356,6 +358,7 @@ private:
   };
 
   PromiseCore_ core_;
+  friend class CoroutineHandle;
 };
 
 /// @}

--- a/uvco/promise/promise.cc
+++ b/uvco/promise/promise.cc
@@ -22,14 +22,6 @@ bool Promise<void>::PromiseAwaiter_::await_ready() const {
   return core_.ready_ || core_.exception_;
 }
 
-std::coroutine_handle<> Promise<void>::PromiseAwaiter_::await_suspend(
-    std::coroutine_handle<> handle) const {
-  BOOST_ASSERT(!core_.ready_ && !core_.exception_);
-  BOOST_ASSERT_MSG(!core_.isAwaited(), "promise is already being waited on!\n");
-  core_.setHandle(handle);
-  return Loop::getNext();
-}
-
 void Promise<void>::PromiseAwaiter_::await_resume() const {
   if (core_.stale()) {
     throw UvcoException(

--- a/uvco/promise/promise.h
+++ b/uvco/promise/promise.h
@@ -4,6 +4,7 @@
 
 #include "uvco/exception.h"
 #include "uvco/promise/promise_core.h"
+#include "uvco/promise/promise_refcount.h"
 
 #include <boost/assert.hpp>
 #include <fmt/format.h>
@@ -65,7 +66,6 @@ public:
   Promise(Promise<T> &&other) noexcept : core_{other.core_} {
     other.core_ = nullptr;
   }
-  /// A promise can be copied at low cost.
   Promise &operator=(const Promise<T> &other) = delete;
   Promise &operator=(Promise<T> &&other) noexcept {
     if (this == &other) {
@@ -78,7 +78,6 @@ public:
     other.core_ = nullptr;
     return *this;
   }
-  // A promise can be copied at low cost.
   Promise(const Promise<T> &other) = delete;
   ~Promise() {
     if (core_ != nullptr) {
@@ -137,8 +136,9 @@ protected:
 
     /// Part of the coroutine protocol: returns if suspension is desired (always
     /// true), and stores the awaiting coroutine state in the `PromiseCore`.
+    template<class PT>
     [[nodiscard]] std::coroutine_handle<>
-    await_suspend(std::coroutine_handle<> handle) const {
+    await_suspend(std::coroutine_handle<PT> handle) const {
       BOOST_ASSERT_MSG(!core_.isAwaited(),
                        "promise is already being waited on!");
       core_.setHandle(handle);
@@ -236,8 +236,15 @@ private:
     [[nodiscard]] bool await_ready() const;
     /// Part of the coroutine protocol: returns if suspension is desired (always
     /// true), and stores the awaiting coroutine state in the `PromiseCore`.
+    template<class PT>
     [[nodiscard]] std::coroutine_handle<>
-    await_suspend(std::coroutine_handle<> handle) const;
+    await_suspend(
+        std::coroutine_handle<PT> handle) const {
+      BOOST_ASSERT(!core_.ready_ && !core_.exception_);
+      BOOST_ASSERT_MSG(!core_.isAwaited(), "promise is already being waited on!\n");
+      core_.setHandle(handle);
+      return Loop::getNext();
+    }
     void await_resume() const;
 
     PromiseCore<void> &core_;
@@ -334,7 +341,9 @@ public:
   // Note: if suspend_always is chosen, we can better control when the promise
   // will be scheduled.
   std::suspend_never initial_suspend() noexcept {
-    core_.setRunning(std::coroutine_handle<Coroutine<T>>::from_promise(*this));
+    auto handle = std::coroutine_handle<Coroutine<T>>::from_promise(*this);
+    core_.setRunning(handle);
+    RunningCoroutine::set(handle);
     return {};
   }
   /// Part of the coroutine protocol: called upon `co_return` or unhandled
@@ -350,6 +359,7 @@ public:
 
 protected:
   PromiseCore<T> core_;
+  friend class CoroutineHandle;
 };
 
 template <> class Coroutine<void> {
@@ -377,8 +387,9 @@ public:
   /// Part of the coroutine protocol: `uvco` coroutines always run until the
   /// first suspension point.
   std::suspend_never initial_suspend() noexcept {
-    core_.setRunning(
-        std::coroutine_handle<Coroutine<void>>::from_promise(*this));
+    auto handle = std::coroutine_handle<Coroutine<void>>::from_promise(*this);
+    core_.setRunning(handle);
+    RunningCoroutine::set(handle);
     return {};
   }
   /// Part of the coroutine protocol: the coroutine stays alive until the
@@ -397,6 +408,7 @@ public:
 
 private:
   PromiseCore_ core_;
+  friend class CoroutineHandle;
 };
 
 /// @}

--- a/uvco/promise/promise_core.cc
+++ b/uvco/promise/promise_core.cc
@@ -13,7 +13,7 @@
 
 namespace uvco {
 
-void PromiseCore<void>::setHandle(std::coroutine_handle<> handle) {
+void PromiseCore<void>::setHandle(CoroutineHandle handle) {
   if (state_ != PromiseState::init) {
     throw UvcoException("PromiseCore is already awaited or has finished");
   }
@@ -22,7 +22,7 @@ void PromiseCore<void>::setHandle(std::coroutine_handle<> handle) {
   state_ = PromiseState::waitedOn;
 }
 
-bool PromiseCore<void>::isAwaited() const { return waitingHandle_ != nullptr; }
+bool PromiseCore<void>::isAwaited() const { return waitingHandle_; }
 bool PromiseCore<void>::ready() const { return exception_ || ready_; }
 bool PromiseCore<void>::stale() const {
   return state_ == PromiseState::finished && !ready();
@@ -31,9 +31,8 @@ bool PromiseCore<void>::stale() const {
 void PromiseCore<void>::resume() {
   if (waitingHandle_) {
     BOOST_ASSERT(state_ == PromiseState::waitedOn);
-    auto waitingHandle = waitingHandle_;
-    waitingHandle_ = nullptr;
-    Loop::enqueue(waitingHandle);
+    Loop::enqueue(std::move(waitingHandle_));
+    waitingHandle_ = {};
   } else {
     // If a coroutine returned immediately, or nobody is co_awaiting the result.
   }
@@ -51,7 +50,7 @@ void PromiseCore<void>::resetHandle() {
   BOOST_ASSERT((state_ == PromiseState::init) ||
                (state_ == PromiseState::waitedOn && waitingHandle_) ||
                (state_ == PromiseState::finished && !waitingHandle_));
-  waitingHandle_ = nullptr;
+  waitingHandle_ = {};
   if (state_ == PromiseState::waitedOn) {
     state_ = PromiseState::init;
   }

--- a/uvco/promise/promise_core.h
+++ b/uvco/promise/promise_core.h
@@ -4,6 +4,7 @@
 
 #include "uvco/exception.h"
 #include "uvco/loop/loop.h"
+#include "uvco/promise/promise_refcount.h"
 
 #include <boost/assert.hpp>
 #include <fmt/core.h>
@@ -55,7 +56,7 @@ public:
       : slot{std::move(value)}, state_{PromiseState::finished} {}
 
   /// Set the coroutine to be resumed once a result is ready.
-  virtual void setHandle(std::coroutine_handle<> handle) {
+  virtual void setHandle(CoroutineHandle handle) {
     if (state_ != PromiseState::init) {
       throw UvcoException("PromiseCore is already awaited or has finished");
     }
@@ -76,13 +77,13 @@ public:
                  (state_ == PromiseState::finished && !waitingHandle_) ||
                  (state_ == PromiseState::init && !waitingHandle_));
     if (state_ == PromiseState::waitedOn) {
-      waitingHandle_ = nullptr;
+      waitingHandle_ = {};
       state_ = PromiseState::init;
     }
   }
 
   /// Checks if a coroutine is waiting on a promise belonging to this core.
-  bool isAwaited() { return waitingHandle_ != nullptr; }
+  bool isAwaited() { return waitingHandle_; }
 
   /// Checks if a value is present in the slot.
   [[nodiscard]] bool ready() const { return slot.has_value(); }
@@ -100,9 +101,8 @@ public:
   void resume() {
     if (waitingHandle_) {
       BOOST_ASSERT(state_ == PromiseState::waitedOn);
-      const std::coroutine_handle<> resume = waitingHandle_;
-      waitingHandle_ = nullptr;
-      Loop::enqueue(resume);
+      Loop::enqueue(std::move(waitingHandle_));
+      waitingHandle_ = {};
     } else {
       // This occurs if no co_await has occured until resume. Either the
       // promise was not co_awaited, or the producing coroutine immediately
@@ -112,9 +112,14 @@ public:
   }
 
   void destroyCoroutine() {
-    if (coroutine_) {
-      Loop::cancel(coroutine_);
-      coroutine_.destroy();
+    refcount_.release();
+  }
+
+  static void pref_deleter(void *vself) {
+    PromiseCore *self = (PromiseCore*)vself;
+    if (self->coroutine_) {
+      Loop::cancel(self->coroutine_);
+      self->coroutine_.destroy();
     }
   }
 
@@ -129,10 +134,12 @@ protected:
   std::coroutine_handle<> coroutine_;
   /// Set to the coroutine awaiting this promise if state_ ==
   /// awaitedOn. May be nullptr.
-  std::coroutine_handle<> waitingHandle_;
+  CoroutineHandle waitingHandle_;
   static_assert(sizeof(std::coroutine_handle<>) <= sizeof(void *),
                 "coroutine_handle is unusually large");
   PromiseState state_ = PromiseState::init;
+  PromiseRefcount refcount_ = {*this};
+  friend class CoroutineHandle;
 };
 
 /// A `void` PromiseCore works like a normal `PromiseCore`, but with the
@@ -151,7 +158,7 @@ public:
   ~PromiseCore() = default;
 
   /// See `PromiseCore::set_resume`.
-  void setHandle(std::coroutine_handle<> handle);
+  void setHandle(CoroutineHandle handle);
 
   /// See `PromiseCore::resetHandle`.
   void resetHandle();
@@ -175,9 +182,14 @@ public:
   // invoked after coroutine completion (due to suspend_always returned from
   // final_suspend).
   void destroyCoroutine() {
-    if (coroutine_) {
-      Loop::cancel(coroutine_);
-      coroutine_.destroy();
+    refcount_.release();
+  }
+
+  static void pref_deleter(void *vself) {
+    PromiseCore *self = (PromiseCore*)vself;
+    if (self->coroutine_) {
+      Loop::cancel(self->coroutine_);
+      self->coroutine_.destroy();
     }
   }
 
@@ -190,8 +202,10 @@ public:
 
 private:
   std::coroutine_handle<> coroutine_;
-  std::coroutine_handle<> waitingHandle_;
+  CoroutineHandle waitingHandle_;
   PromiseState state_ = PromiseState::init;
+  PromiseRefcount refcount_ = {*this};
+  friend class CoroutineHandle;
 };
 
 /// @}

--- a/uvco/promise/promise_refcount.h
+++ b/uvco/promise/promise_refcount.h
@@ -31,12 +31,14 @@ class PromiseRefcounter_ {
     if (refs || weaks) return false;
     return true;
   }
-public:
+
+  friend class CoroutineHandle;
+  friend class PromiseRefcount;
   PromiseRefcounter_(decltype(deleter.fun) fun, decltype(deleter.data) data) {
     deleter.fun = fun;
     deleter.data = data;
   }
-
+public:
   size_t uses() { return refs; }
   size_t weak_uses() { return weaks; }
 
@@ -132,10 +134,11 @@ public:
   }
 
   bool operator==(std::nullptr_t) const {
-    return ref == nullptr;
+    return (!(ref && ref->uses())) || handle == nullptr;
   }
 
   bool operator==(const CoroutineHandle& other) const {
+    BOOST_ASSERT(ref != other.ref || handle == other.handle);
     return ref == other.ref;
   }
 
@@ -145,7 +148,7 @@ public:
   }
 
   operator bool () const {
-    return (ref && ref->uses());
+    return *this != nullptr;
   }
 
   /// Resume the coroutine, updating `RunningCoroutine` in the process.
@@ -212,14 +215,14 @@ void CoroutineHandle::resume() const {
 /// This forms a chain/tree of references, so that a CancellationBlock can
 /// block the destruction of the entire async call chain.
 class PromiseRefcount {
-public:
-  PromiseRefcounter_ *inner;
-
+  template<class T> friend class PromiseCore;
   template<class T>
   PromiseRefcount(T& obj) {
     inner = new PromiseRefcounter_(T::pref_deleter, &obj);
     inner->setParent(RunningCoroutine::get());
   }
+public:
+  PromiseRefcounter_ *inner;
 
   PromiseRefcount(const PromiseRefcount &) = delete;
   PromiseRefcount(PromiseRefcount &&) = delete;

--- a/uvco/promise/promise_refcount.h
+++ b/uvco/promise/promise_refcount.h
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 kimapr.  See LICENSE for specific terms.
+
+#pragma once
+
+#include <coroutine>
+#include <cstddef>
+
+namespace uvco {
+
+class CoroutineHandle;
+
+class PromiseRefcounter_ {
+  size_t refs = 1;
+  size_t weaks = 0;
+  PromiseRefcounter_ *parent = nullptr; // weakref
+  struct { void (*fun)(void*) = nullptr; void *data = nullptr; } deleter;
+
+  // return true if delete
+  bool checkRefs() {
+    if (deleter.data && !refs) {
+      auto data = deleter.data;
+      deleter.data = nullptr;
+      deleter.fun(data);
+      if (parent) {
+        auto p = parent;
+        parent = nullptr;
+        if (p->releaseWeak())
+          delete p;
+      }
+    }
+    if (refs || weaks) return false;
+    return true;
+  }
+public:
+  PromiseRefcounter_(decltype(deleter.fun) fun, decltype(deleter.data) data) {
+    deleter.fun = fun;
+    deleter.data = data;
+  }
+
+  size_t uses() { return refs; }
+  size_t weak_uses() { return weaks; }
+
+  void setParent(PromiseRefcounter_ *np) {
+    if (parent) parent->releaseWeak();
+    parent = np;
+    if (parent)
+      parent->acquireWeak();
+  }
+
+  inline void setParent(const CoroutineHandle&);
+
+  bool release() {
+    BOOST_ASSERT(refs);
+    refs--; return checkRefs(); }
+  bool releaseWeak() {
+    BOOST_ASSERT(weaks);
+    weaks--; return checkRefs(); }
+  void acquire() {
+    refs++;
+  }
+  void acquireWeak() {
+    weaks++;
+  }
+
+  static void acquireRecursive(PromiseRefcounter_ *ref) {
+    while (ref) {
+      ref->refs++;
+      if (ref->parent && !ref->parent->refs) {
+        if (ref->parent->releaseWeak())
+          delete ref->parent;
+        ref->parent = nullptr;
+      }
+      ref = ref->parent;
+    }
+  }
+
+  static void releaseRecursive(PromiseRefcounter_ *ref) {
+    while (ref) {
+      ref->refs--;
+      auto p = ref->parent;
+      if (p) p->weaks++;
+      if (ref->checkRefs())
+        delete ref;
+      if (p) p->weaks--;
+      ref = p;
+    }
+  }
+};
+
+class ObtainCoroutineHandleAwaiter;
+
+/// Represents a type-erased coroutine handle with refcounting information
+/// preserved.
+class CoroutineHandle {
+  std::coroutine_handle<> handle;
+  PromiseRefcounter_ *ref = nullptr;
+  friend class CancellationBlock;
+  friend class PromiseRefcounter_;
+
+public:
+  CoroutineHandle() = default;
+
+  /// Construct a `CoroutineHandle` from a typed coroutine handle (typically
+  /// obtained from a templated `await_suspend()`).
+  template<class T>
+  CoroutineHandle(std::coroutine_handle<T> handle) : handle(handle), ref(handle.promise().core_.refcount_.inner) { ref->acquireWeak(); }
+  CoroutineHandle(std::coroutine_handle<> handle, PromiseRefcounter_ *ref) : handle(handle), ref(ref) { ref->acquireWeak(); }
+  CoroutineHandle(std::nullptr_t) {}
+
+  ~CoroutineHandle() { if (ref) if(ref->releaseWeak()) delete ref; }
+
+  CoroutineHandle(const CoroutineHandle &rhs) : handle(rhs.handle), ref(rhs.ref) { if(ref) ref->acquireWeak(); }
+  CoroutineHandle(CoroutineHandle &&rhs) : handle(rhs.handle), ref(rhs.ref) { rhs.handle = {}; rhs.ref = {}; }
+  CoroutineHandle &operator=(const CoroutineHandle &rhs) {
+    if (*this == rhs) return *this;
+    if (ref) if (ref->releaseWeak()) delete ref;
+    handle = rhs.handle; ref = rhs.ref;
+    if (ref) ref->acquireWeak();
+    return *this;
+  }
+  CoroutineHandle &operator=(CoroutineHandle &&rhs) {
+    if (*this == rhs) return *this;
+    if (ref) if (ref->releaseWeak()) delete ref;
+    handle = rhs.handle; ref = rhs.ref;
+    rhs.handle = {}; rhs.ref = {};
+    return *this;
+  }
+
+  operator std::coroutine_handle<> () const {
+    if (!*this) return std::noop_coroutine();
+    return handle;
+  }
+
+  bool operator==(std::nullptr_t) const {
+    return ref == nullptr;
+  }
+
+  bool operator==(const CoroutineHandle& other) const {
+    return ref == other.ref;
+  }
+
+  bool operator==(std::coroutine_handle<> other) const {
+    if (!*this) return other == nullptr;
+    return handle == other;
+  }
+
+  operator bool () const {
+    return (ref && ref->uses());
+  }
+
+  /// Resume the coroutine, updating `RunningCoroutine` in the process.
+  ///
+  /// If the coroutine has been destroyed, this method is a no-op.
+  inline void resume() const;
+
+  /// Construct a `CoroutineHandle` for the currently running coroutine.
+  /// The returned value needs to be `co_await`ed (this will not actually
+  /// suspend the coroutine).
+  inline ObtainCoroutineHandleAwaiter getCurrent();
+};
+
+void PromiseRefcounter_::setParent(const CoroutineHandle& handle) {
+  setParent(handle.ref);
+}
+
+class ObtainCoroutineHandleAwaiter {
+  CoroutineHandle handle;
+  friend class CoroutineHandle;
+  ObtainCoroutineHandleAwaiter() = default;
+public:
+  bool await_ready() { return false; }
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> coro) {
+    handle = {coro};
+    return false;
+  }
+  CoroutineHandle await_resume() { return std::move(handle); }
+};
+
+inline ObtainCoroutineHandleAwaiter CoroutineHandle::getCurrent() { return {}; }
+
+/// Keeps track of the currently running coroutine in a thread-local variable.
+/// This is a bit of a hack, as the language does not offer a proper way to do
+/// this. The current coroutine should be set when a coroutine is first started,
+/// by the promise_type, and `CoroutineHandler::resume` should be used elsewhere.
+///
+/// When making a custom awaiter care should be taken to set the running
+/// coroutine appropriately.
+class RunningCoroutine {
+  inline thread_local static CoroutineHandle currentCoroutine = {};
+  RunningCoroutine() = delete;
+public:
+  static void set(CoroutineHandle coro) { currentCoroutine = coro; }
+  static CoroutineHandle get() { return currentCoroutine; }
+};
+
+void CoroutineHandle::resume() const {
+  if (!*this) return;
+  struct Restorer {
+    CoroutineHandle handle;
+    Restorer(CoroutineHandle handle) : handle(handle) {}
+    ~Restorer() { RunningCoroutine::set(handle); }
+  } restorer(RunningCoroutine::get());
+  RunningCoroutine::set(*this);
+  handle.resume();
+}
+
+/// Internal object stored in coroutine frames, used for CancellationBlock.
+///
+/// When creating a `PromiseRefcount` for a coroutine, it is associated with
+/// the currently running coroutine (normally the caller of an async function).
+/// This forms a chain/tree of references, so that a CancellationBlock can
+/// block the destruction of the entire async call chain.
+class PromiseRefcount {
+public:
+  PromiseRefcounter_ *inner;
+
+  template<class T>
+  PromiseRefcount(T& obj) {
+    inner = new PromiseRefcounter_(T::pref_deleter, &obj);
+    inner->setParent(RunningCoroutine::get());
+  }
+
+  PromiseRefcount(const PromiseRefcount &) = delete;
+  PromiseRefcount(PromiseRefcount &&) = delete;
+  PromiseRefcount &operator=(const PromiseRefcount &) = delete;
+  PromiseRefcount &operator=(PromiseRefcount &&) = delete;
+
+  void release() {
+    PromiseRefcounter_ *ptr = inner;
+    inner = nullptr;
+    if (ptr->release())
+      delete ptr;
+  }
+};
+
+} // namespace uvco

--- a/uvco/promise/select.h
+++ b/uvco/promise/select.h
@@ -79,7 +79,8 @@ public:
 
   /// Register the current coroutine to be resumed when one of the promises is
   /// ready.
-  std::coroutine_handle<> await_suspend(std::coroutine_handle<> handle) {
+  template<class T>
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<T> handle) {
     std::apply(
         [handle](auto *...promise) {
           ((!promise->core()->stale() ? promise->core()->setHandle(handle)
@@ -129,7 +130,7 @@ private:
   }
 
   Tuple promises_;
-  std::coroutine_handle<> suspended_;
+  CoroutineHandle suspended_;
   bool resumed_ = false;
 };
 

--- a/uvco/stream.cc
+++ b/uvco/stream.cc
@@ -13,6 +13,7 @@
 #include "uvco/promise/promise.h"
 #include "uvco/run.h"
 #include "uvco/stream.h"
+#include "uvco/cancellation_block.h"
 
 #include <array>
 #include <coroutine>
@@ -30,10 +31,11 @@ struct StreamBase::ShutdownAwaiter_ {
   static void onShutdown(uv_shutdown_t *req, uv_status status);
 
   bool await_ready();
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   void await_resume();
 
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   std::optional<uv_status> status_;
 };
 
@@ -43,7 +45,8 @@ struct StreamBase::InStreamAwaiter_ {
   ~InStreamAwaiter_();
 
   bool await_ready();
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   size_t await_resume();
 
   void start_read();
@@ -57,7 +60,7 @@ struct StreamBase::InStreamAwaiter_ {
   StreamBase &stream_;
   std::span<char> buffer_;
   std::optional<ssize_t> status_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
 };
 
 struct StreamBase::OutStreamAwaiter_ {
@@ -65,12 +68,13 @@ struct StreamBase::OutStreamAwaiter_ {
   ~OutStreamAwaiter_();
 
   bool await_ready();
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   uv_status await_resume();
 
   static void onOutStreamWrite(uv_write_t *write, uv_status status);
 
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   std::optional<uv_status> status_;
 
   // State necessary for both immediate and delayed writing.
@@ -157,7 +161,11 @@ Promise<void> StreamBase::writeVectored(std::span<IoVec> bufs) {
     throw UvcoException{
         status, "StreamBase::writeVectored() encountered error in uv_write"};
   }
-  status = co_await awaiter;
+  {
+    CancellationBlock block;
+    status = co_await awaiter;
+    co_await block;
+  }
   if (status < 0) {
     throw UvcoException{
         status,
@@ -178,17 +186,17 @@ Promise<void> StreamBase::shutdown() {
 }
 
 void StreamBase::close() {
-  if (stream_ != nullptr) {
+  if (stream_) {
     closeHandle(stream_.release());
   }
-  if (reader_ != nullptr) {
-    std::coroutine_handle<> reader = reader_;
-    reader_ = nullptr;
+  if (reader_) {
+    auto reader = reader_;
+    reader_ = {};
     reader.resume();
   }
-  if (writer_ != nullptr) {
-    std::coroutine_handle<> writer = writer_;
-    writer_ = nullptr;
+  if (writer_) {
+    auto writer = writer_;
+    writer_ = {};
     writer.resume();
   }
 }
@@ -203,7 +211,7 @@ StreamBase::InStreamAwaiter_::~InStreamAwaiter_() {
   if (stream_.stream_ != nullptr) {
     resetData(&stream_.stream());
   }
-  stream_.reader_ = nullptr;
+  stream_.reader_ = {};
 }
 
 bool StreamBase::InStreamAwaiter_::await_ready() {
@@ -217,8 +225,9 @@ bool StreamBase::InStreamAwaiter_::await_ready() {
   return status_.has_value();
 }
 
+template<class T>
 bool StreamBase::InStreamAwaiter_::await_suspend(
-    std::coroutine_handle<> handle) {
+    std::coroutine_handle<T> handle) {
   BOOST_ASSERT(dataIsNull(&stream_.stream()));
   setData(&stream_.stream(), this);
   handle_ = handle;
@@ -232,7 +241,7 @@ size_t StreamBase::InStreamAwaiter_::await_resume() {
     return 0;
   }
   BOOST_ASSERT(status_);
-  stream_.reader_ = nullptr;
+  stream_.reader_ = {};
   if (status_ && *status_ == UV_EOF) {
     return 0;
   }
@@ -282,7 +291,7 @@ void StreamBase::InStreamAwaiter_::onInStreamRead(uv_stream_t *stream,
 
   if (awaiter->handle_) {
     Loop::enqueue(awaiter->handle_);
-    awaiter->handle_ = nullptr;
+    awaiter->handle_ = {};
   }
   setData(stream, (void *)nullptr);
 }
@@ -291,7 +300,7 @@ StreamBase::OutStreamAwaiter_::OutStreamAwaiter_(StreamBase &stream)
     : write_{}, stream_{stream} {}
 
 StreamBase::OutStreamAwaiter_::~OutStreamAwaiter_() {
-  stream_.writer_ = nullptr;
+  stream_.writer_ = {};
 }
 
 bool StreamBase::OutStreamAwaiter_::await_ready() {
@@ -299,8 +308,9 @@ bool StreamBase::OutStreamAwaiter_::await_ready() {
   return false;
 }
 
+template<class T>
 bool StreamBase::OutStreamAwaiter_::await_suspend(
-    std::coroutine_handle<> handle) {
+    std::coroutine_handle<T> handle) {
   BOOST_ASSERT(dataIsNull(&write_));
   setData(&write_, this);
   handle_ = handle;
@@ -316,7 +326,7 @@ uv_status StreamBase::OutStreamAwaiter_::await_resume() {
     return UV_ECANCELED;
   }
   BOOST_ASSERT(status_);
-  stream_.writer_ = nullptr;
+  stream_.writer_ = {};
   setData(&write_, (void *)nullptr);
   return *status_;
 }
@@ -328,14 +338,15 @@ void StreamBase::OutStreamAwaiter_::onOutStreamWrite(uv_write_t *write,
   awaiter->status_ = status;
   BOOST_ASSERT(awaiter->handle_);
   Loop::enqueue(awaiter->handle_);
-  awaiter->handle_ = nullptr;
+  awaiter->handle_ = {};
   setData(write, (void *)nullptr);
 }
 
 bool StreamBase::ShutdownAwaiter_::await_ready() { return false; }
 
+template<class T>
 bool StreamBase::ShutdownAwaiter_::await_suspend(
-    std::coroutine_handle<> handle) {
+    std::coroutine_handle<T> handle) {
   BOOST_ASSERT(!handle_);
   handle_ = handle;
   return true;
@@ -354,7 +365,7 @@ void StreamBase::ShutdownAwaiter_::onShutdown(uv_shutdown_t *req,
   awaiter->status_ = status;
   if (awaiter->handle_) {
     Loop::enqueue(awaiter->handle_);
-    awaiter->handle_ = nullptr;
+    awaiter->handle_ = {};
   }
 }
 

--- a/uvco/stream.cc
+++ b/uvco/stream.cc
@@ -61,10 +61,8 @@ struct StreamBase::InStreamAwaiter_ {
 };
 
 struct StreamBase::OutStreamAwaiter_ {
-  OutStreamAwaiter_(StreamBase &stream, std::span<const char> buffer);
+  OutStreamAwaiter_(StreamBase &stream);
   ~OutStreamAwaiter_();
-
-  [[nodiscard]] std::array<uv_buf_t, 1> prepare_buffers() const;
 
   bool await_ready();
   bool await_suspend(std::coroutine_handle<> handle);
@@ -76,7 +74,6 @@ struct StreamBase::OutStreamAwaiter_ {
   std::optional<uv_status> status_;
 
   // State necessary for both immediate and delayed writing.
-  std::span<const char> buffer_;
   uv_write_t write_{};
   StreamBase &stream_;
 };
@@ -111,34 +108,62 @@ Promise<size_t> StreamBase::read(std::span<char> buffer) {
   co_return (co_await awaiter);
 }
 
-Promise<size_t> StreamBase::write(std::string buf) {
+Promise<void> StreamBase::write(std::string buf) {
   co_return (co_await writeBorrowed(std::span{buf}));
 }
 
-Promise<size_t> StreamBase::writeBorrowed(std::span<const char> buffer) {
-  OutStreamAwaiter_ awaiter{*this, buffer};
-  std::array<uv_buf_t, 1> bufs{};
-  bufs[0] = uv_buf_init(const_cast<char *>(buffer.data()), buffer.size());
+Promise<void> StreamBase::writeBorrowed(std::span<const char> buffer) {
+  std::array<IoVec, 1> bufs{IoVec(buffer)};
+  co_return (co_await writeVectored(bufs));
+}
 
-  uv_status status = uv_try_write(&stream(), bufs.data(), bufs.size());
-  if (status > 0) {
-    // Already done, nothing had to be queued.
-    co_return static_cast<size_t>(status);
+Promise<void> StreamBase::writeVectored(std::span<IoVec> bufs) {
+  OutStreamAwaiter_ awaiter{*this};
+
+  uv_status status = uv_try_write(&stream(), (uv_buf_t*)bufs.data(), bufs.size());
+
+  if (status < 0 && status != UV_EAGAIN) {
+    throw UvcoException{
+        status, "StreamBase::writeVectored() encountered error in uv_try_write"};
   }
 
-  status = uv_write(&awaiter.write_, &stream(), bufs.data(), bufs.size(),
+  struct Restorer {
+    IoVec *target = nullptr;
+    IoVec value;
+    ~Restorer() { if (target) *target = value; }
+  } restorer;
+
+  if (status > 0) {
+    while (bufs.size() > 0) {
+      if (bufs[0].size() <= (size_t)status) {
+        status -= bufs[0].size();
+        bufs = bufs.subspan(1);
+        continue;
+      }
+
+      restorer.target = &bufs[0];
+      restorer.value = bufs[0];
+      bufs[0] = IoVec{bufs[0].data()+status, bufs[0].size()-status};
+      break;
+    }
+
+    if (bufs.size() == 0)
+      co_return;
+  }
+
+  status = uv_write(&awaiter.write_, &stream(), (uv_buf_t*)bufs.data(), bufs.size(),
                     OutStreamAwaiter_::onOutStreamWrite);
   if (status < 0) {
     throw UvcoException{
-        status, "StreamBase::writeBorrowed() encountered error in uv_write"};
+        status, "StreamBase::writeVectored() encountered error in uv_write"};
   }
   status = co_await awaiter;
   if (status < 0) {
     throw UvcoException{
         status,
-        "StreamBase::writeBorrowed() encountered error while awaiting write"};
+        "StreamBase::writeVectored() encountered error while awaiting write"};
   }
-  co_return static_cast<size_t>(status);
+  co_return;
 }
 
 Promise<void> StreamBase::shutdown() {
@@ -262,18 +287,11 @@ void StreamBase::InStreamAwaiter_::onInStreamRead(uv_stream_t *stream,
   setData(stream, (void *)nullptr);
 }
 
-StreamBase::OutStreamAwaiter_::OutStreamAwaiter_(StreamBase &stream,
-                                                 std::span<const char> buffer)
-    : buffer_{buffer}, write_{}, stream_{stream} {}
+StreamBase::OutStreamAwaiter_::OutStreamAwaiter_(StreamBase &stream)
+    : write_{}, stream_{stream} {}
 
 StreamBase::OutStreamAwaiter_::~OutStreamAwaiter_() {
   stream_.writer_ = nullptr;
-}
-
-std::array<uv_buf_t, 1> StreamBase::OutStreamAwaiter_::prepare_buffers() const {
-  std::array<uv_buf_t, 1> bufs{};
-  bufs[0] = uv_buf_init(const_cast<char *>(buffer_.data()), buffer_.size());
-  return bufs;
 }
 
 bool StreamBase::OutStreamAwaiter_::await_ready() {

--- a/uvco/stream.h
+++ b/uvco/stream.h
@@ -96,13 +96,9 @@ public:
   Promise<size_t> read(std::span<char> buffer);
 
   /// Write a buffer to the stream. A copy of `buf` is taken because it is
-  /// undetermined when the actual write will occur. Await the result if the
-  /// status is important; the write will be executed even without awaiting (as
-  /// long as the process keeps running).
-  ///
-  /// NOTE: only one writer is allowed to be active at a time. If two writes
-  /// are started simultaneously, the process will be aborted in Debug mode, or
-  /// the first `write()` coroutine will not return in Release mode.
+  /// undetermined when the actual write will occur. Cancelling the operation
+  /// by destroying the returned promise before it resolves results in
+  /// undefined behavior.
   [[nodiscard]] Promise<void> write(std::string buf);
 
   /// The same as `write(std::string)`, but takes a borrowed buffer. `buf` MUST

--- a/uvco/stream.h
+++ b/uvco/stream.h
@@ -26,6 +26,29 @@ namespace uvco {
 /// @addtogroup Stream
 /// @{
 
+/// A buffer pointer type suitable for vectored I/O. Can be constructed with the
+/// same arguments as a std::span<const char> object, and be implicitly
+/// converted to a std::span<const char> object.
+class IoVec {
+  uv_buf_t buf_;
+public:
+  template<class... Args>
+  IoVec(Args&&... args) {
+    std::span<const char> buf(std::forward<Args>(args)...);
+    buf_.base = (char*)buf.data();
+    buf_.len = buf.size();
+  }
+  constexpr IoVec& operator=( const IoVec& other ) = default;
+  constexpr IoVec& operator=( const std::span<const char>& other ) {
+    IoVec v(other);
+    buf_ = v.buf_;
+    return *this;
+  }
+  constexpr const char *data() { return (const char *)buf_.base; }
+  constexpr size_t size() { return buf_.len; }
+  operator std::span<const char> () const { return { buf_.base, buf_.len }; }
+};
+
 /// A plain stream, permitting reading, writing, and closing.
 class StreamBase {
   struct ShutdownAwaiter_;
@@ -80,13 +103,21 @@ public:
   /// NOTE: only one writer is allowed to be active at a time. If two writes
   /// are started simultaneously, the process will be aborted in Debug mode, or
   /// the first `write()` coroutine will not return in Release mode.
-  [[nodiscard]] Promise<size_t> write(std::string buf);
+  [[nodiscard]] Promise<void> write(std::string buf);
 
   /// The same as `write(std::string)`, but takes a borrowed buffer. `buf` MUST
   /// absolutely stay valid until the promise resolves. This means: co_await
   /// this method and call it with a stored buffer (not a function return value,
   /// for example).
-  [[nodiscard]] Promise<size_t> writeBorrowed(std::span<const char> buf);
+  [[nodiscard]] Promise<void> writeBorrowed(std::span<const char> buf);
+
+  /// The same as `writeBorrowed(std::span<const char>)`, but takes multiple
+  /// buffers, and writes them out in-order.
+  ///
+  /// NOTE: writeVectored may modify the `IoVec`s (not the buffer contents
+  /// themselves) during writing, although it will restore the original values
+  /// after completion. Do not use the `IoVec`s until the write is complete.
+  [[nodiscard]] Promise<void> writeVectored(std::span<IoVec> bufs);
 
   /// Shut down stream for writing. This is a half-close; the other side
   /// can still write. The result of `shutdown()` *must be `co_await`ed*.

--- a/uvco/stream.h
+++ b/uvco/stream.h
@@ -142,8 +142,8 @@ private:
   std::unique_ptr<uv_stream_t, UvHandleDeleter> stream_;
 
   // Currently suspended readers/writers to be notified on close().
-  std::coroutine_handle<> reader_;
-  std::coroutine_handle<> writer_;
+  CoroutineHandle reader_;
+  CoroutineHandle writer_;
 };
 
 /// A stream referring to stdin/stdout/stderr. Should be created using one of

--- a/uvco/stream.h
+++ b/uvco/stream.h
@@ -33,7 +33,7 @@ class IoVec {
   uv_buf_t buf_;
 public:
   template<class... Args>
-  IoVec(Args&&... args) {
+  constexpr IoVec(Args&&... args) {
     std::span<const char> buf(std::forward<Args>(args)...);
     buf_.base = (char*)buf.data();
     buf_.len = buf.size();
@@ -46,7 +46,7 @@ public:
   }
   constexpr const char *data() { return (const char *)buf_.base; }
   constexpr size_t size() { return buf_.len; }
-  operator std::span<const char> () const { return { buf_.base, buf_.len }; }
+  constexpr operator std::span<const char> () const { return { buf_.base, buf_.len }; }
 };
 
 /// A plain stream, permitting reading, writing, and closing.

--- a/uvco/stream_server_base_impl.cc
+++ b/uvco/stream_server_base_impl.cc
@@ -37,7 +37,12 @@ struct StreamServerBase<UvStreamType, StreamType>::ConnectionAwaiter_ {
   ~ConnectionAwaiter_() { resetData(&socket_); }
 
   [[nodiscard]] bool await_ready() const;
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<typename PromiseType>
+  bool await_suspend(std::coroutine_handle<PromiseType> handle) {
+    BOOST_ASSERT(!handle_);
+    handle_ = handle;
+    return true;
+  }
   // Returns true if one or more connections were accepted.
   // Returns false if the listener should stop.
   [[nodiscard]] bool await_resume() const { return !stopped_; }
@@ -46,7 +51,7 @@ struct StreamServerBase<UvStreamType, StreamType>::ConnectionAwaiter_ {
   void stop();
 
   UvStreamType &socket_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
 
   // Set of accepted connections or errors.
   using Accepted = std::variant<uv_status, StreamType>;
@@ -61,21 +66,13 @@ void StreamServerBase<UvStreamType, StreamType>::ConnectionAwaiter_::stop() {
     return;
   }
   stopped_ = true;
-  if (handle_ != nullptr) {
+  if (handle_) {
     // Synchronous resume to ensure that the listener is stopped by the time
     // the function returns.
-    const std::coroutine_handle<> handle = handle_;
-    handle_ = nullptr;
+    const auto handle = handle_;
+    handle_ = {};
     handle.resume();
   }
-}
-
-template <typename UvStreamType, typename StreamType>
-bool StreamServerBase<UvStreamType, StreamType>::ConnectionAwaiter_::
-    await_suspend(std::coroutine_handle<> handle) {
-  BOOST_ASSERT(handle_ == nullptr);
-  handle_ = handle;
-  return true;
 }
 
 template <typename UvStreamType, typename StreamType>
@@ -109,9 +106,9 @@ void StreamServerBase<UvStreamType, StreamType>::onNewConnection(
     connectionAwaiter->accepted_.emplace_back(status);
   }
 
-  if (connectionAwaiter->handle_ != nullptr) {
+  if (connectionAwaiter->handle_) {
     Loop::enqueue(connectionAwaiter->handle_);
-    connectionAwaiter->handle_ = nullptr;
+    connectionAwaiter->handle_ = {};
   }
 }
 

--- a/uvco/tcp.cc
+++ b/uvco/tcp.cc
@@ -30,14 +30,15 @@ struct TcpClient::ConnectAwaiter_ {
   ~ConnectAwaiter_();
 
   [[nodiscard]] bool await_ready() const;
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   TcpStream await_resume();
 
   void onConnect(uv_status status);
 
   std::unique_ptr<uv_connect_t> req_;
   std::unique_ptr<uv_tcp_t> socket_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   std::optional<uv_status> status_;
 };
 
@@ -74,7 +75,8 @@ bool TcpClient::ConnectAwaiter_::await_ready() const {
   return status_.has_value();
 }
 
-bool TcpClient::ConnectAwaiter_::await_suspend(std::coroutine_handle<> handle) {
+template<class T>
+bool TcpClient::ConnectAwaiter_::await_suspend(std::coroutine_handle<T> handle) {
   BOOST_ASSERT(!handle_);
   handle_ = handle;
   return true;

--- a/uvco/timer.cc
+++ b/uvco/timer.cc
@@ -58,12 +58,13 @@ public:
   }
 
   bool await_ready() { return isReady(); }
-  std::coroutine_handle<> await_suspend(std::coroutine_handle<> handle) {
+  template<class T>
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<T> handle) {
     handle_ = handle;
     return Loop::getNext();
   }
   [[nodiscard]] bool await_resume() {
-    handle_ = nullptr;
+    handle_ = {};
     return !stopped_;
   }
 
@@ -80,13 +81,13 @@ public:
   void resume() {
     if (handle_) {
       Loop::enqueue(handle_);
-      handle_ = nullptr;
+      handle_ = {};
     }
   }
 
 private:
   std::unique_ptr<uv_timer_t> timer_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   bool closed_ = false;
   bool stopped_ = false;
 };

--- a/uvco/udp.cc
+++ b/uvco/udp.cc
@@ -45,12 +45,13 @@ struct Udp::RecvAwaiter_ {
   ~RecvAwaiter_() = default;
 
   [[nodiscard]] bool await_ready() const;
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   std::optional<std::pair<std::string, AddressHandle>> await_resume();
 
   uv_udp_t &udp_;
   BoundedQueue<QueueItem_> buffer_;
-  std::optional<std::coroutine_handle<>> handle_;
+  std::optional<CoroutineHandle> handle_;
   bool stop_receiving_ = true;
 };
 
@@ -63,11 +64,12 @@ struct Udp::SendAwaiter_ {
   ~SendAwaiter_() { resetData(&req_); }
 
   [[nodiscard]] bool await_ready() const;
-  bool await_suspend(std::coroutine_handle<> h);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> h);
   int await_resume();
 
   uv_udp_send_t &req_;
-  std::optional<std::coroutine_handle<>> handle_;
+  std::optional<CoroutineHandle> handle_;
   std::optional<int> status_;
 };
 
@@ -294,7 +296,7 @@ void Udp::onReceiveOne(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf,
   // Only enqueues once; if this callback is called again, the receiver will
   // already have been resumed.
   if (awaiter->handle_) {
-    std::coroutine_handle<void> resumeHandle = *awaiter->handle_;
+    auto resumeHandle = *awaiter->handle_;
     awaiter->handle_.reset();
     Loop::enqueue(resumeHandle);
   }
@@ -379,7 +381,8 @@ std::optional<AddressHandle> Udp::getPeername() const {
 Udp::RecvAwaiter_::RecvAwaiter_(uv_udp_t &udp, size_t queueSize)
     : udp_{udp}, buffer_{queueSize} {}
 
-bool Udp::RecvAwaiter_::await_suspend(std::coroutine_handle<> handle) {
+template<class T>
+bool Udp::RecvAwaiter_::await_suspend(std::coroutine_handle<T> handle) {
   BOOST_ASSERT(dataIsNull(&udp_));
   setData(&udp_, this);
   BOOST_ASSERT(!handle_);
@@ -412,7 +415,7 @@ void Udp::onSendDone(uv_udp_send_t *req, uv_status status) {
   }
   awaiter->status_ = status;
   if (awaiter->handle_) {
-    std::coroutine_handle<void> resumeHandle = *awaiter->handle_;
+    auto resumeHandle = *awaiter->handle_;
     awaiter->handle_.reset();
     Loop::enqueue(resumeHandle);
   }
@@ -420,7 +423,8 @@ void Udp::onSendDone(uv_udp_send_t *req, uv_status status) {
 
 bool Udp::SendAwaiter_::await_ready() const { return status_.has_value(); }
 
-bool Udp::SendAwaiter_::await_suspend(std::coroutine_handle<> handle) {
+template<class T>
+bool Udp::SendAwaiter_::await_suspend(std::coroutine_handle<T> handle) {
   setData(&req_, this);
   BOOST_ASSERT(!handle_);
   handle_ = handle;

--- a/uvco/uds.cc
+++ b/uvco/uds.cc
@@ -92,7 +92,7 @@ Promise<UnixStream> UnixStreamClient::connect(std::string_view path) {
                         "UnixStreamClient::connect() failed immediately");
   }
 #else
-  uv_pipe_connect(&request_, pipe_.get(), path_.data(), onConnect);
+  uv_pipe_connect(connect.request_.get(), connect.pipe_.get(), path.data(), ConnectAwaiter_::onConnect);
 #endif
 
   std::optional<UvcoException> maybeError;

--- a/uvco/uds.cc
+++ b/uvco/uds.cc
@@ -51,12 +51,13 @@ struct UnixStreamClient::ConnectAwaiter_ {
   static void onConnect(uv_connect_t *req, uv_status status);
 
   [[nodiscard]] static bool await_ready();
-  bool await_suspend(std::coroutine_handle<> handle);
+  template<class T>
+  bool await_suspend(std::coroutine_handle<T> handle);
   UnixStream await_resume();
 
   std::unique_ptr<uv_connect_t> request_{};
   std::unique_ptr<uv_pipe_t> pipe_;
-  std::coroutine_handle<> handle_;
+  CoroutineHandle handle_;
   uv_status status_{};
 };
 
@@ -127,8 +128,9 @@ void UnixStreamClient::ConnectAwaiter_::onConnect(uv_connect_t *req,
 
 bool UnixStreamClient::ConnectAwaiter_::await_ready() { return false; }
 
+template<class T>
 bool UnixStreamClient::ConnectAwaiter_::await_suspend(
-    std::coroutine_handle<> handle) {
+    std::coroutine_handle<T> handle) {
   BOOST_ASSERT(handle_ == nullptr);
   handle_ = handle;
   setRequestData(request_.get(), this);


### PR DESCRIPTION
I am trying to use uvco to build a web application, and while doing so found a few bugs and areas in uvco that could be improved.  I gathered the changes together as they are ~~small~~ mostly small and there's a few of them.  This merge request addresses the following:

- Since I am using the GNU Build System rather than CMake, the CMake files provided by uvco are not too useful for me.  Hence the new pkg-config files, which can be imported by a wide variety of build systems besides CMake.  For the pkg-config file to be usable uvco must be "installed" somewhere, and the installed pkgconfig directory must be in `PKG_CONFIG_PATH`.
- My system packages older libuv (1.44.2) and there's erroneous code in a normally-disabled preprocessor branch in uvco that makes the build fail with it.
- `TaskSet` improperly discards the user-passed coroutine, causing the objects in its argument list to linger for longer than it should.
- The way StreamBase write functions handle partial results and the status codes from libuv is subtly wrong.  `uv_try_write` returns success if a partial write occurs, and uvco just gives up with the rest of the write and returns the number of bytes written in that case.  If however, the write would completely block, it would wait for `uv_write` and return 0.  I made it consistently perform a full write and since the return value is bogus anyway i replaced it with void.  I didn't actually test if the original code actually misbehaves in reality but it's pretty apparent just by reading the code and libuv docs that it's incorrect.  I did test it after my changes though and it doesn't exhibit the issues i predicted when writing to a slow reader.
- Vectored writes!  Very handy as it allows you to perform a single write from multiple unrelated parts without extra copies.  E.g. if you want to send a HTTP chunk, instead of constructing a buffer and copying all of the data and chunk metadata there, you can just gather 3 buffer references together (one for the chunk size header, the payload itself, and the terminating CRLF each) and write them in one call.
- Some operations are unsafe to cancel, in particular stream writes. Stream writes now use the new CancellationBlock primitive that keeps a whole call chain of coroutines alive to avoid use-after-free bugs

~~There's also one **big** issue I found but have not addressed since I am not quite sure how exactly to do that (see #4)~~ EDIT: this is now addressed  by this PR